### PR TITLE
Run tests on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - 3.6
+before_install:
+  - pip install -U pip
+  - pip install -r requirements.txt
+script:
+  - python -m pytest tests
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - 3.6
 before_install:


### PR DESCRIPTION
This pull request solves the issue #3 . Dependencies are cached, so it doesn't need to download everything on each run.

Example of CI execution: https://travis-ci.org/yabirgb/simobility/builds/642552673